### PR TITLE
Redesign home navigation dashboard

### DIFF
--- a/web/components/AiDailyBoard.tsx
+++ b/web/components/AiDailyBoard.tsx
@@ -109,7 +109,7 @@ export default function AiDailyBoard({ manifest, initial }: AiDailyBoardProps) {
 
   if (total === 0 || !meta) {
     return (
-      <section>
+      <section className="rounded-[2rem] border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:p-6">
         <HeaderStrip onExport={handleExport} onShare={handleShare} exporting={exporting} sharing={sharing} hasContent={false} />
         <TabMenu tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
         <div className="flex h-80 flex-col items-center justify-center gap-4 rounded-3xl border border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
@@ -121,7 +121,7 @@ export default function AiDailyBoard({ manifest, initial }: AiDailyBoardProps) {
   }
 
   return (
-    <section>
+    <section className="rounded-[2rem] border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:p-6">
       <HeaderStrip onExport={handleExport} onShare={handleShare} exporting={exporting} sharing={sharing} hasContent={!!data} />
       <TabMenu tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
 
@@ -178,7 +178,7 @@ export default function AiDailyBoard({ manifest, initial }: AiDailyBoardProps) {
           id="daily-panel-card"
           role="tabpanel"
           aria-labelledby="daily-tab-card"
-          className="overflow-hidden rounded-3xl border border-gray-200 bg-gray-50 shadow-sm dark:border-gray-800 dark:bg-gray-900/50"
+          className="overflow-hidden rounded-3xl border border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50"
         >
           <div className="flex justify-center overflow-x-auto p-4 sm:p-6">
             {data ? (
@@ -197,7 +197,7 @@ export default function AiDailyBoard({ manifest, initial }: AiDailyBoardProps) {
           id="daily-panel-highlights"
           role="tabpanel"
           aria-labelledby="daily-tab-highlights"
-          className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-6"
+          className="rounded-3xl border border-gray-200 bg-gray-50 p-5 dark:border-gray-800 dark:bg-gray-900 sm:p-6"
         >
           <p className="text-xs font-semibold uppercase tracking-[0.15em] text-gray-400 dark:text-gray-500">本期摘要</p>
           <ul className="mt-4 space-y-3">
@@ -254,15 +254,15 @@ function HeaderStrip({
   hasContent: boolean;
 }) {
   return (
-    <div className="mb-4 flex items-end justify-between gap-4">
+    <div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
       <div>
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">AI Daily</p>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">Daily Brief</p>
         <h2 className="mt-1 text-2xl font-bold text-gray-900 dark:text-white sm:text-3xl">每日精选</h2>
         <p className="mt-1.5 text-sm leading-6 text-gray-500 dark:text-gray-400">
           精选 AI Coding &amp; 具身智能最新动态 · 每日 09:00 自动更新
         </p>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
           自动同步中
@@ -302,9 +302,8 @@ function TabMenu({
   onChange: (tab: 'card' | 'highlights') => void;
 }) {
   return (
-    <div className="mb-4 border-b border-gray-200 dark:border-gray-800">
-      <p className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-gray-400 dark:text-gray-500">二级菜单</p>
-      <div className="flex items-center gap-2 overflow-x-auto pb-2" role="tablist" aria-label="每日精选二级菜单">
+    <div className="mb-4">
+      <div className="inline-flex rounded-full border border-gray-200 bg-gray-50 p-1 dark:border-gray-800 dark:bg-gray-900" role="tablist" aria-label="每日精选视图切换">
         {tabs.map((tab) => {
           const isActive = tab.key === activeTab;
           return (
@@ -318,8 +317,8 @@ function TabMenu({
               onClick={() => onChange(tab.key)}
               className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
                 isActive
-                  ? 'bg-blue-600 text-white shadow-sm'
-                  : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-600'
+                  ? 'bg-gray-900 text-white shadow-sm dark:bg-white dark:text-gray-950'
+                  : 'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'
               }`}
             >
               {tab.label}

--- a/web/components/AiRadarHome.tsx
+++ b/web/components/AiRadarHome.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link';
 import {
-  FileText,
-  Languages,
-  BookOpen,
   ArrowRight,
   CalendarDays,
+  ClipboardList,
+  Newspaper,
+  QrCode,
+  Radio,
 } from 'lucide-react';
 import HomeSignalTabs from '@/components/HomeSignalTabs';
-import UniversalShareButton from '@/components/UniversalShareButton';
 import { getAllWeeklies } from '@/lib/weekly';
 import { getAiHotFeed } from '@/lib/ai-hot-feed';
 import { getDailyManifest, getLatestDaily } from '@/lib/ai-daily';
@@ -17,33 +17,6 @@ export const metadata = {
     '每日精选 AI Coding / Agent / 大模型动态，每周沉淀一份前端周刊。不做信息搬运，只做信号筛选。',
 };
 
-const moreFormats = [
-  {
-    icon: <FileText className="h-4 w-4" />,
-    accent: 'text-orange-600 dark:text-orange-400',
-    eyebrow: '每日速递',
-    title: '短文速递 · 24h 快讯',
-    desc: '300-500 字，每日 1-3 条。把关键信号转成中文判断，适合快速浏览和转发。',
-    tier: '短文',
-  },
-  {
-    icon: <Languages className="h-4 w-4" />,
-    accent: 'text-violet-600 dark:text-violet-400',
-    eyebrow: '每周精译',
-    title: '中文精译 · 优质长文翻译',
-    desc: '1500-3000 字，每周 2-3 篇。重写标题、结构和表达，读起来像中文作者写的。',
-    tier: '中文精译',
-  },
-  {
-    icon: <BookOpen className="h-4 w-4" />,
-    accent: 'text-amber-600 dark:text-amber-400',
-    eyebrow: '月度深读',
-    title: '长文深读 · 论文级解读',
-    desc: '5000+ 字，每月 1-2 篇。补足背景、画出技术关系图，给出明确行动建议。',
-    tier: '长文深读',
-  },
-];
-
 export default function AiRadarHome() {
   const weeklies = getAllWeeklies();
   const [featured, ...rest] = weeklies;
@@ -51,19 +24,86 @@ export default function AiRadarHome() {
   const feed = getAiHotFeed();
   const dailyManifest = getDailyManifest();
   const latestDaily = getLatestDaily();
+  const boardCards = [
+    {
+      href: '#live',
+      icon: Radio,
+      label: '7×24 资讯',
+      value: `${feed.items.length} 条`,
+      desc: '实时捕捉 AI、Agent、前端和科技信号。',
+    },
+    {
+      href: '#daily',
+      icon: Newspaper,
+      label: '每日精选',
+      value: dailyManifest.latest ? dailyManifest.latest.slice(5) : '09:00',
+      desc: '每天把噪音过滤成少量值得看的判断。',
+    },
+    {
+      href: '#plan',
+      icon: ClipboardList,
+      label: '计划',
+      value: '5 阶段',
+      desc: '从信息摄入落到前端转 AI Agent 的行动路线。',
+    },
+    {
+      href: '#contact',
+      icon: QrCode,
+      label: '二维码',
+      value: '扫码',
+      desc: '获取更新、联系作者或咨询 1v1。',
+    },
+  ];
 
   return (
     <div className="container mx-auto px-4 py-8 md:px-6">
       <div className="mx-auto max-w-6xl">
         {/* ── Hero ── */}
-        <header className="mb-10">
-          <h1 className="text-3xl font-extrabold leading-tight tracking-tight text-gray-900 dark:text-white md:text-4xl">
-            站在前沿端点，
-            <span className="text-blue-600 dark:text-blue-400">每周看世界所发生的变化</span>
-          </h1>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-500 dark:text-gray-400">
-            7×24 小时实时资讯，每日精选 AI Coding / Agent / 大模型动态，每周沉淀一份前端周刊。不做信息搬运，只做信号筛选——不求多，有一条能给你一点启发就够。
-          </p>
+        <header className="mb-10 overflow-hidden rounded-[2rem] border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-950 md:p-8">
+          <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">Frontend Weekly Radar</p>
+              <h1 className="mt-4 text-3xl font-extrabold leading-tight tracking-tight text-gray-900 dark:text-white md:text-5xl">
+                一个看板，串起资讯、精选、计划和联系入口
+              </h1>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-gray-500 dark:text-gray-400 md:text-base">
+                先看 7×24 实时信号，再读每日精选判断；如果想把信息变成行动，就进入转型计划，最后通过二维码获取更新或联系作者。
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <Link
+                  href="#live"
+                  className="inline-flex items-center gap-1.5 rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+                >
+                  进入看板
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="/roadmap"
+                  className="inline-flex items-center gap-1.5 rounded-full border border-gray-300 px-5 py-2.5 text-sm font-semibold text-gray-900 transition hover:border-gray-400 dark:border-gray-700 dark:text-gray-100"
+                >
+                  查看计划
+                </Link>
+              </div>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {boardCards.map(({ href, icon: Icon, label, value, desc }) => (
+                <Link
+                  key={label}
+                  href={href}
+                  className="group rounded-3xl border border-gray-200 bg-gray-50 p-4 transition hover:-translate-y-0.5 hover:border-blue-200 hover:bg-blue-50/70 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-blue-900/60 dark:hover:bg-blue-950/20"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white text-blue-600 shadow-sm dark:bg-gray-950 dark:text-blue-300">
+                      <Icon className="h-5 w-5" />
+                    </span>
+                    <span className="text-sm font-black text-gray-900 dark:text-white">{value}</span>
+                  </div>
+                  <h2 className="mt-4 text-sm font-bold text-gray-900 dark:text-white">{label}</h2>
+                  <p className="mt-1 text-xs leading-5 text-gray-500 dark:text-gray-400">{desc}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
         </header>
 
         <HomeSignalTabs
@@ -72,40 +112,6 @@ export default function AiRadarHome() {
           dailyManifest={dailyManifest.list}
           latestDaily={latestDaily}
         />
-
-        {/* ── 更多内容形态：短文 / 中文 / 长文 ── */}
-        <section className="mt-16">
-          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500">
-            更多内容形态
-          </p>
-          <div className="grid gap-4 md:grid-cols-3">
-            {moreFormats.map((f) => (
-              <div
-                key={f.title}
-                className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-950"
-              >
-                <p className={`flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] ${f.accent}`}>
-                  {f.icon}
-                  {f.eyebrow}
-                </p>
-                <h3 className="mt-3 text-lg font-bold text-gray-900 dark:text-white">{f.title}</h3>
-                <p className="mt-2 text-sm leading-6 text-gray-500 dark:text-gray-400">{f.desc}</p>
-                <div className="mt-4">
-                  <UniversalShareButton
-                    kind="format"
-                    title={f.title}
-                    summary={f.desc}
-                    source="前端周看"
-                    tier={f.tier}
-                    href="/"
-                    label="分享模版"
-                    className="inline-flex items-center gap-1 rounded-full border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:border-gray-400 dark:border-gray-700 dark:text-gray-200"
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
 
         {/* ── 本周精选 ── */}
         {featured && (

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Github, MessageCircle } from 'lucide-react';
@@ -10,19 +11,38 @@ interface HeaderProps {
   weeklyHref?: string;
 }
 
+type NavItem = {
+  href: string;
+  label: string;
+  mobileLabel?: string;
+  match: (p: string, hash: string) => boolean;
+};
+
 export default function Header({ weeklyHref = '/weekly' }: HeaderProps) {
   const pathname = usePathname();
-  const navItems: { href: string; label: string; match: (p: string) => boolean }[] = [
-    { href: '/', label: '情报看板', match: (p) => p === '/' || p.startsWith('/ai-radar') },
-    { href: '/#live', label: '7×24 资讯', match: () => false },
-    { href: '/#daily', label: '每日精选', match: () => false },
-    { href: '/roadmap', label: '转型计划', match: (p) => p.startsWith('/roadmap') },
-    { href: weeklyHref, label: '前端周刊', match: (p) => p.startsWith('/weekly') },
+  const [hash, setHash] = useState('');
+  const navItems: NavItem[] = [
+    { href: '/', label: '情报看板', mobileLabel: '看板', match: (p, h) => (p === '/' && !h) || p.startsWith('/ai-radar') },
+    { href: '/#live', label: '7×24 资讯', mobileLabel: '7×24', match: (p, h) => p === '/' && h === '#live' },
+    { href: '/#daily', label: '每日精选', mobileLabel: '每日', match: (p, h) => p === '/' && h === '#daily' },
+    { href: '/roadmap', label: '转型计划', mobileLabel: '计划', match: (p) => p.startsWith('/roadmap') },
+    { href: weeklyHref, label: '前端周刊', mobileLabel: '周刊', match: (p) => p.startsWith('/weekly') },
   ];
+  const mobileNavItems: NavItem[] = [
+    ...navItems,
+    { href: '/#contact', label: '联系/二维码', mobileLabel: '二维码', match: (p, h) => p === '/' && h === '#contact' },
+  ];
+
+  useEffect(() => {
+    const syncHash = () => setHash(window.location.hash);
+    syncHash();
+    window.addEventListener('hashchange', syncHash);
+    return () => window.removeEventListener('hashchange', syncHash);
+  }, []);
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-gray-200 bg-white/80 backdrop-blur-md dark:border-gray-800 dark:bg-gray-950/80">
-      <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-6">
+      <div className="container mx-auto flex h-14 items-center justify-between px-4 md:h-16 md:px-6">
         <div className="flex items-center gap-6">
           <BrandLogo />
           <nav className="hidden md:flex items-center gap-1 text-sm font-medium text-gray-600 dark:text-gray-400">
@@ -32,7 +52,7 @@ export default function Header({ weeklyHref = '/weekly' }: HeaderProps) {
                   href={item.href}
                   className={cn(
                     'rounded-full px-3 py-1.5 transition-colors hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-950/40 dark:hover:text-blue-300',
-                    item.match(pathname) ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300 font-bold' : ''
+                    item.match(pathname, hash) ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300 font-bold' : ''
                   )}
                 >
                   {item.label}
@@ -60,6 +80,27 @@ export default function Header({ weeklyHref = '/weekly' }: HeaderProps) {
           </a>
         </div>
       </div>
+      <nav className="border-t border-gray-100 bg-white/90 dark:border-gray-900 dark:bg-gray-950/90 md:hidden" aria-label="H5 主导航">
+        <div className="custom-scrollbar container mx-auto flex gap-2 overflow-x-auto px-4 py-2">
+          {mobileNavItems.map((item) => {
+            const isActive = item.match(pathname, hash);
+            return (
+              <Link
+                key={item.label}
+                href={item.href}
+                className={cn(
+                  'inline-flex min-h-9 shrink-0 items-center justify-center rounded-full border px-3.5 text-xs font-semibold transition',
+                  isActive
+                    ? 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900/60 dark:bg-blue-950/40 dark:text-blue-300'
+                    : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300 dark:hover:border-gray-700 dark:hover:text-white'
+                )}
+              >
+                {item.mobileLabel ?? item.label}
+              </Link>
+            );
+          })}
+        </div>
+      </nav>
     </header>
   );
 }

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Github, Sparkles } from 'lucide-react';
+import { Github, MessageCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import BrandLogo from '@/components/BrandLogo';
 
@@ -13,8 +13,10 @@ interface HeaderProps {
 export default function Header({ weeklyHref = '/weekly' }: HeaderProps) {
   const pathname = usePathname();
   const navItems: { href: string; label: string; match: (p: string) => boolean }[] = [
-    { href: '/', label: '每日精选', match: (p) => p === '/' || p.startsWith('/ai-radar') },
-    { href: '/roadmap', label: '转型路线', match: (p) => p.startsWith('/roadmap') },
+    { href: '/', label: '情报看板', match: (p) => p === '/' || p.startsWith('/ai-radar') },
+    { href: '/#live', label: '7×24 资讯', match: () => false },
+    { href: '/#daily', label: '每日精选', match: () => false },
+    { href: '/roadmap', label: '转型计划', match: (p) => p.startsWith('/roadmap') },
     { href: weeklyHref, label: '前端周刊', match: (p) => p.startsWith('/weekly') },
   ];
 
@@ -23,17 +25,14 @@ export default function Header({ weeklyHref = '/weekly' }: HeaderProps) {
       <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-6">
         <div className="flex items-center gap-6">
           <BrandLogo />
-          <nav className="hidden md:flex items-center gap-5 text-sm font-medium text-gray-600 dark:text-gray-400">
-            {navItems.map((item, idx) => (
-              <span key={item.label} className="inline-flex items-center gap-5">
-                {idx > 0 ? (
-                  <span className="select-none text-gray-300 dark:text-gray-700">|</span>
-                ) : null}
+          <nav className="hidden md:flex items-center gap-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+            {navItems.map((item) => (
+              <span key={item.label} className="inline-flex items-center">
                 <Link
                   href={item.href}
                   className={cn(
-                    'transition-colors hover:text-blue-600 dark:hover:text-blue-400',
-                    item.match(pathname) ? 'text-blue-600 dark:text-blue-400 font-bold' : ''
+                    'rounded-full px-3 py-1.5 transition-colors hover:bg-blue-50 hover:text-blue-700 dark:hover:bg-blue-950/40 dark:hover:text-blue-300',
+                    item.match(pathname) ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300 font-bold' : ''
                   )}
                 >
                   {item.label}
@@ -44,14 +43,11 @@ export default function Header({ weeklyHref = '/weekly' }: HeaderProps) {
         </div>
         <div className="flex items-center gap-3">
           <Link
-            href="/pro"
-            className={cn(
-              'hidden sm:inline-flex items-center gap-1.5 rounded-full bg-gray-900 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200',
-              pathname.startsWith('/pro') ? 'ring-2 ring-gray-400 dark:ring-gray-600' : ''
-            )}
+            href="/#contact"
+            className="hidden sm:inline-flex items-center gap-1.5 rounded-full bg-gray-900 px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
           >
-            <Sparkles className="h-3.5 w-3.5" />
-            1v1 交流
+            <MessageCircle className="h-3.5 w-3.5" />
+            联系/二维码
           </Link>
           <a
             href="https://github.com/TUARAN/frontend-weekly-digest-cn"

--- a/web/components/HomeSignalTabs.tsx
+++ b/web/components/HomeSignalTabs.tsx
@@ -50,8 +50,8 @@ export default function HomeSignalTabs({
 
   return (
     <section className="mt-8" aria-label="首页情报看板">
-      <div id="live" className="scroll-mt-24" />
-      <div id="daily" className="scroll-mt-24" />
+      <div id="live" className="scroll-mt-28 md:scroll-mt-24" />
+      <div id="daily" className="scroll-mt-28 md:scroll-mt-24" />
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="min-w-0">
           <div

--- a/web/components/HomeSignalTabs.tsx
+++ b/web/components/HomeSignalTabs.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, ClipboardList, Newspaper, QrCode, Radio } from 'lucide-react';
 import AiDailyBoard from '@/components/AiDailyBoard';
 import LiveSignalBoard from '@/components/LiveSignalBoard';
 import type { FeedItem } from '@/lib/ai-hot-feed';
@@ -20,55 +22,134 @@ export default function HomeSignalTabs({
   latestDaily,
 }: HomeSignalTabsProps) {
   const [activeTab, setActiveTab] = useState<'live' | 'daily'>('live');
+  const latestDailyMeta = dailyManifest[0] ?? null;
+  const dashboardTabs = [
+    {
+      key: 'live',
+      label: '7×24 资讯',
+      description: `${feedItems.length} 条实时信号`,
+      icon: Radio,
+    },
+    {
+      key: 'daily',
+      label: '每日精选',
+      description: latestDailyMeta ? `${latestDailyMeta.displayDate} · ${latestDailyMeta.count} 条` : '每日 09:00 更新',
+      icon: Newspaper,
+    },
+  ] as const;
+
+  useEffect(() => {
+    const syncTabWithHash = () => {
+      if (window.location.hash === '#daily') setActiveTab('daily');
+      if (window.location.hash === '#live') setActiveTab('live');
+    };
+    syncTabWithHash();
+    window.addEventListener('hashchange', syncTabWithHash);
+    return () => window.removeEventListener('hashchange', syncTabWithHash);
+  }, []);
 
   return (
-    <section className="mt-2">
-      <div className="mb-5 border-b border-gray-200 dark:border-gray-800">
-        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-gray-400 dark:text-gray-500">内容分区</p>
-        <div className="flex items-center gap-2 overflow-x-auto pb-2" role="tablist" aria-label="首页内容切换">
-          <button
-            type="button"
-            role="tab"
-            id="home-tab-live"
-            aria-selected={activeTab === 'live'}
-            aria-controls="home-panel-live"
-            onClick={() => setActiveTab('live')}
-            className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
-              activeTab === 'live'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-600'
-            }`}
+    <section className="mt-8" aria-label="首页情报看板">
+      <div id="live" className="scroll-mt-24" />
+      <div id="daily" className="scroll-mt-24" />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="min-w-0">
+          <div
+            className="mb-5 grid gap-3 rounded-[2rem] border border-gray-200 bg-white p-2 shadow-sm dark:border-gray-800 dark:bg-gray-950 sm:grid-cols-2"
+            role="tablist"
+            aria-label="首页内容切换"
           >
-            7×24 小时资讯
-          </button>
-          <button
-            type="button"
-            role="tab"
-            id="home-tab-daily"
-            aria-selected={activeTab === 'daily'}
-            aria-controls="home-panel-daily"
-            onClick={() => setActiveTab('daily')}
-            className={`rounded-full px-4 py-1.5 text-sm font-medium transition ${
-              activeTab === 'daily'
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'border border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:hover:border-gray-600'
-            }`}
-          >
-            每日精选
-          </button>
-        </div>
-      </div>
+            {dashboardTabs.map(({ key, label, description, icon: Icon }) => {
+              const isActive = activeTab === key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  role="tab"
+                  id={`home-tab-${key}`}
+                  aria-selected={isActive}
+                  aria-controls={`home-panel-${key}`}
+                  onClick={() => setActiveTab(key)}
+                  className={`flex items-center gap-3 rounded-[1.5rem] p-4 text-left transition ${
+                    isActive
+                      ? 'bg-gray-900 text-white shadow-sm dark:bg-white dark:text-gray-950'
+                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-900 dark:hover:text-white'
+                  }`}
+                >
+                  <span
+                    className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl ${
+                      isActive
+                        ? 'bg-white/15 text-white dark:bg-gray-950/10 dark:text-gray-950'
+                        : 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300'
+                    }`}
+                  >
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <span>
+                    <span className="block text-sm font-bold">{label}</span>
+                    <span className={`mt-1 block text-xs ${isActive ? 'text-white/70 dark:text-gray-600' : 'text-gray-500 dark:text-gray-400'}`}>
+                      {description}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
 
-      {activeTab === 'live' ? (
-        <div id="home-panel-live" role="tabpanel" aria-labelledby="home-tab-live">
-          <LiveSignalBoard items={feedItems} updatedAt={feedUpdatedAt} />
+          {activeTab === 'live' ? (
+            <div id="home-panel-live" role="tabpanel" aria-labelledby="home-tab-live">
+              <LiveSignalBoard items={feedItems} updatedAt={feedUpdatedAt} />
+            </div>
+          ) : (
+            <div id="home-panel-daily" role="tabpanel" aria-labelledby="home-tab-daily">
+              <AiDailyBoard manifest={dailyManifest} initial={latestDaily} />
+            </div>
+          )}
         </div>
-      ) : (
-        <div id="home-panel-daily" role="tabpanel" aria-labelledby="home-tab-daily">
-          <AiDailyBoard manifest={dailyManifest} initial={latestDaily} />
-        </div>
-      )}
+
+        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+          <div id="plan" className="rounded-[2rem] border border-blue-100 bg-gradient-to-br from-blue-50 via-white to-indigo-50 p-6 shadow-sm dark:border-blue-900/40 dark:from-blue-950/30 dark:via-gray-950 dark:to-indigo-950/30">
+            <div className="flex items-center gap-3">
+              <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-blue-600 text-white shadow-sm">
+                <ClipboardList className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-300">Plan</p>
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white">前端转 AI Agent 路线</h2>
+              </div>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">
+              把「要不要转」「学什么」「做出什么作品」拆成 5 个阶段，作为每日信息之外的行动地图。
+            </p>
+            <Link
+              href="/roadmap"
+              className="mt-5 inline-flex items-center gap-1.5 rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            >
+              查看计划
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+
+          <div id="contact" className="rounded-[2rem] border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-950">
+            <div className="flex items-center gap-3">
+              <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gray-900 text-white dark:bg-white dark:text-gray-950">
+                <QrCode className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-400">QR Code</p>
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white">扫码获取更新</h2>
+              </div>
+            </div>
+            <div className="mt-5 rounded-3xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-900">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/qrcode1.jpg" alt="前端周看二维码" className="mx-auto aspect-square w-40 rounded-2xl bg-white object-cover p-2" />
+            </div>
+            <p className="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">
+              关注后获取每日精选、路线图更新和周刊推送；需要 1v1 也可以直接留言。
+            </p>
+          </div>
+        </aside>
+      </div>
     </section>
   );
 }
-

--- a/web/components/LiveSignalBoard.tsx
+++ b/web/components/LiveSignalBoard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import type { CSSProperties } from 'react';
+import { useState } from 'react';
 import { Copy, ExternalLink, Radio } from 'lucide-react';
 import type { FeedItem } from '@/lib/ai-hot-feed';
 import UniversalShareButton from '@/components/UniversalShareButton';
@@ -19,7 +18,7 @@ function fmtCST(iso?: string | null): string {
   return `${M}月${D}日 ${h}:${m}`;
 }
 
-function SignalCard({ item }: { item: FeedItem }) {
+function SignalCard({ item, featured = false }: { item: FeedItem; featured?: boolean }) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
@@ -34,7 +33,11 @@ function SignalCard({ item }: { item: FeedItem }) {
   }
 
   return (
-    <article className="rounded-2xl border border-gray-200 bg-white/90 p-4 shadow-sm backdrop-blur dark:border-gray-800 dark:bg-gray-950/85">
+    <article
+      className={`rounded-2xl border border-gray-200 bg-white/90 shadow-sm backdrop-blur transition hover:border-blue-200 hover:shadow-md dark:border-gray-800 dark:bg-gray-950/85 dark:hover:border-blue-900/60 ${
+        featured ? 'p-5 sm:p-6' : 'p-4'
+      }`}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -45,12 +48,16 @@ function SignalCard({ item }: { item: FeedItem }) {
               <span className="text-xs text-gray-500 dark:text-gray-400">{fmtCST(item.publishedAt)}</span>
             )}
           </div>
-          <h3 className="text-base font-semibold leading-6 text-gray-900 dark:text-white">{item.title}</h3>
+          <h3 className={`${featured ? 'text-xl leading-7' : 'text-base leading-6'} font-semibold text-gray-900 dark:text-white`}>
+            {item.title}
+          </h3>
         </div>
       </div>
 
       {item.summary && (
-        <p className="mt-3 line-clamp-4 text-sm leading-6 text-gray-600 dark:text-gray-400">{item.summary}</p>
+        <p className={`${featured ? 'line-clamp-5' : 'line-clamp-3'} mt-3 text-sm leading-6 text-gray-600 dark:text-gray-400`}>
+          {item.summary}
+        </p>
       )}
 
       <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -88,31 +95,6 @@ function SignalCard({ item }: { item: FeedItem }) {
       </div>
     </article>
   );
-}
-
-function SignalStream({ items }: { items: FeedItem[] }) {
-  // 至少复制一遍以实现无缝循环滚动
-  const loopItems = useMemo(() => (items.length > 0 ? [...items, ...items] : []), [items]);
-  // 关键：条目越多，总滚动距离越长，时长也要同步拉长，避免体感“越多越快”。
-  const durationSeconds = useMemo(() => Math.max(180, items.length * 16), [items.length]);
-  const trackStyle = useMemo(
-    () =>
-      ({
-        '--signal-duration': `${durationSeconds}s`,
-      }) as CSSProperties,
-    [durationSeconds]
-  );
-
-  return (
-    <div className="signal-marquee relative h-[520px] overflow-hidden sm:h-[640px]">
-      <div className="signal-track" style={trackStyle}>
-        {loopItems.map((item, index) => (
-          <div key={`${item.href}-${index}`} className="mb-4">
-            <SignalCard item={item} />
-          </div>
-        ))}
-      </div>
-    </div>
   );
 }
 
@@ -122,8 +104,11 @@ interface LiveSignalBoardProps {
 }
 
 export default function LiveSignalBoard({ items, updatedAt }: LiveSignalBoardProps) {
+  const [featured, ...rest] = items;
+  const visibleRest = rest.slice(0, 6);
+
   return (
-    <section className="mx-auto max-w-6xl rounded-3xl border border-gray-200 bg-gradient-to-br from-white to-gray-50 p-5 shadow-sm dark:border-gray-800 dark:from-gray-950 dark:to-gray-900 sm:p-8">
+    <section className="mx-auto rounded-[2rem] border border-gray-200 bg-gradient-to-br from-white to-gray-50 p-5 shadow-sm dark:border-gray-800 dark:from-gray-950 dark:to-gray-900 sm:p-8">
       <div className="mb-8 flex flex-wrap items-end justify-between gap-3">
         <div>
           <p className="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.2em] text-blue-600 dark:text-blue-400">
@@ -136,15 +121,34 @@ export default function LiveSignalBoard({ items, updatedAt }: LiveSignalBoardPro
           </p>
         </div>
         {updatedAt && (
-          <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
-            <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
-            更新于 {fmtCST(updatedAt)}
-          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-gray-100 px-3 py-1.5 text-xs font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+              {items.length} 条信号
+            </span>
+            <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+              <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+              更新于 {fmtCST(updatedAt)}
+            </span>
+          </div>
         )}
       </div>
 
-      {items.length > 0 ? (
-        <SignalStream items={items} />
+      {featured ? (
+        <div className="space-y-4">
+          <SignalCard item={featured} featured />
+          {visibleRest.length > 0 ? (
+            <div className="grid gap-4 xl:grid-cols-2">
+              {visibleRest.map((item) => (
+                <SignalCard key={item.href} item={item} />
+              ))}
+            </div>
+          ) : null}
+          {items.length > visibleRest.length + 1 ? (
+            <p className="rounded-2xl border border-dashed border-gray-200 bg-white/70 px-4 py-3 text-center text-xs text-gray-500 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-400">
+              当前看板先展示最新 {visibleRest.length + 1} 条，其余信号会在后续精选中沉淀。
+            </p>
+          ) : null}
+        </div>
       ) : (
         <div className="flex h-40 items-center justify-center text-sm text-gray-400">资讯即将上线，敬请期待</div>
       )}

--- a/web/components/LiveSignalBoard.tsx
+++ b/web/components/LiveSignalBoard.tsx
@@ -95,7 +95,6 @@ function SignalCard({ item, featured = false }: { item: FeedItem; featured?: boo
       </div>
     </article>
   );
-  );
 }
 
 interface LiveSignalBoardProps {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align header navigation around the four primary surfaces: 7x24 feed, daily digest, transformation plan, and QR/contact.
- Rework the homepage hero into a four-card dashboard overview and remove the confusing extra content-format block.
- Redesign the live feed and daily board presentation with clearer cards, side actions, and stable section anchors.
- Add an H5/mobile horizontal navigation bar under the header with compact labels for 看板 / 7x24 / 每日 / 计划 / 周刊 / 二维码.

## Testing
- `npx eslint components/Header.tsx components/HomeSignalTabs.tsx` ✅
- `npx eslint components/Header.tsx components/AiRadarHome.tsx components/HomeSignalTabs.tsx components/LiveSignalBoard.tsx components/AiDailyBoard.tsx` ✅
- `npx eslint . --quiet` ❌ blocked by existing unrelated lint errors in `app/api/tool/jobs/route.ts`, `article-extractor/**`, `fetch-translate-tool/**`, and `components/SyncToBlogButton.tsx`.
- `npm run build` ❌ blocked by existing `/api/og/share` static export configuration error (`output: export` requires static/revalidate config).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3676889d-e1dd-41bb-8c56-05d9a15a0ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3676889d-e1dd-41bb-8c56-05d9a15a0ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

